### PR TITLE
Fixed startup crash caused by font issue

### DIFF
--- a/Source/Display.cpp
+++ b/Source/Display.cpp
@@ -65,7 +65,7 @@ DisplayLookAndFeel::DisplayLookAndFeel() {
 
 Typeface::Ptr DisplayLookAndFeel::getCustomTypeface() {
     if (!customTypeface)
-        customTypeface = juce::Typeface::createSystemTypefaceFor(BinaryData::DSEG14ClassicItalic_ttf, BinaryData::DSEG14ClassicItalic_ttfSize);
+        customTypeface = Typeface::createSystemTypefaceFor(BinaryData::DSEG14ClassicItalic_ttf, BinaryData::DSEG14ClassicItalic_ttfSize);
     return customTypeface;
 }
 

--- a/Source/MainComponent.h
+++ b/Source/MainComponent.h
@@ -47,13 +47,13 @@ public:
 
     Logo logo;
     
-    Font descriptionTextFont = Font(FontOptions("Arial", 16.0f, Font::italic));
+    Font descriptionTextFont = Font(FontOptions(Font::getDefaultSansSerifFontName(), 16.0f, Font::italic));
     Colour descriptionTextColour = Colour::fromRGB(170, 170, 170);
 
-    Font sectionsTextFont = Font(FontOptions("Arial", 16.0f, Font::bold));
+    Font sectionsTextFont = Font(FontOptions(Font::getDefaultSansSerifFontName(), 16.0f, Font::bold));
     Colour sectionsTextColour = Colour::fromRGB(255, 255, 225);
 
-    Font menusTextFont = Font(FontOptions("Arial", 16.0f, Font::plain));
+    Font menusTextFont = Font(FontOptions(Font::getDefaultSansSerifFontName(), 16.0f, Font::plain));
     Colour menusTextColour = Colour::fromRGB(255, 255, 240);
 
     // Colours depending on the currently connected model. First is SQ-80, second is ESQ-1, then unknown.

--- a/Source/PannelButton.cpp
+++ b/Source/PannelButton.cpp
@@ -29,7 +29,7 @@ PannelButton::PannelButton(const Colour& color, const String& text, const int& x
 	label.setJustificationType(Justification::centred);
 	label.attachToComponent(this, true);
 	label.setColour(Label::textColourId, buttonTextColour);
-	label.setFont(Font("Arial", 16.0f, Font::italic));
+	label.setFont(Font(FontOptions(Font::getDefaultSansSerifFontName(), 16.0f, Font::italic)));
 	label.setBounds(xPos - buttonWidth / 2, yPos - 20, 2 * buttonWidth, 0.5 * buttonHeight);
 }
 


### PR DESCRIPTION
This fixes a startup crash on Linux, and _possibly_ on certain Windows environments as well. More testing to come.